### PR TITLE
feat(api-compat): pick up apicompat-suppressions.xml from repo root

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -21,6 +21,14 @@ name: API Compatibility
 #
 # Skips cleanly with exit 0 if no stable version is on nuget.org yet
 # (e.g. a repo that hasn't shipped 1.0).
+#
+# Intentional breaks (e.g. major-version bumps) can be suppressed by
+# checking in an `apicompat-suppressions.xml` at the repo root with the
+# format documented at:
+#   https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/diagnostic-ids
+# When present, the file is passed to apicompat via --suppression-file so
+# listed CP-codes are downgraded from errors. Each entry should carry a
+# Justification so future readers know why the break was permitted.
 
 on:
   workflow_call:
@@ -80,4 +88,11 @@ jobs:
           mkdir -p ./baseline
           curl -sL "https://api.nuget.org/v3-flatcontainer/${pkg_lower}/${latest}/${pkg_lower}.${latest}.nupkg" \
                -o ./baseline/baseline.nupkg
-          apicompat package ./current/*.nupkg --baseline-package ./baseline/baseline.nupkg
+
+          suppression_args=()
+          if [ -f ./apicompat-suppressions.xml ]; then
+            echo "Found apicompat-suppressions.xml — applying."
+            suppression_args+=(--suppression-file ./apicompat-suppressions.xml)
+          fi
+
+          apicompat package ./current/*.nupkg --baseline-package ./baseline/baseline.nupkg "${suppression_args[@]}"


### PR DESCRIPTION
## Summary

Reusable api-compat workflow now passes `--suppression-file ./apicompat-suppressions.xml` to `apicompat package` when the consuming repo checks in that file at its root.

## Why

Major-version bumps are *intentional* breaks — the workflow's own comment says: *"Major bumps temporarily fire on intentional breaks — accept that as the cost of correctness."* Today consumers have no way to acknowledge an intentional break short of disabling the gate. With this change, the consumer commits a small XML file listing each break + justification, and CI passes.

Format: standard ApiCompat suppression XML — see [Microsoft docs](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/diagnostic-ids).

## First consumer

ZeroAlloc.Mediator PR #63 (3.0.0) — drops `IMediatorBuilder.Create` static interface method. Will add `apicompat-suppressions.xml` once this lands.

## Test plan

- [x] `bash` array expansion correctly omits `--suppression-file` when no file present (suppression_args="" empty array; works under `set -e` because bash 4+ handles empty `${arr[@]}`)
- [x] No-suppressions consumers (e.g. ZeroAlloc.Inject, ZeroAlloc.Pipeline) keep working — no behavior change
- [x] When the file exists, it's logged and forwarded to apicompat verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)